### PR TITLE
image/ssh-regen: remove keys and always regen if missing

### DIFF
--- a/tasks/image_configuration/ssh-regen-keys/Kconfig
+++ b/tasks/image_configuration/ssh-regen-keys/Kconfig
@@ -1,7 +1,16 @@
 config DS_REGENERATE_SSH_KEYS
 	default y
-	bool "Regenerate SSH keys on first boot"
+	bool "Regenerate SSH keys (YOU REALLY WANT THIS IF INSTALLING SSHD)"
 	help
-	  Regenerate SSH keys during first boot. Otherwise if ssh is included
-	  in the image, all images would have the same keys. You should say
-	  'y' here unless ssh is not included in the image.
+	  Remove target image's generated SSH host keys and generate new host
+	  keys at system bootup if they do not exist.
+
+	  This has the side effect of generating host keys on boot if they are
+	  removed for any reason. If you want to disable sshd, disable it from
+	  starting instead of removing its keys.
+
+	  Otherwise, the image generated will have the keys baked in to it and
+	  all devices the image is installed to will have the same keys.
+
+	  YOU REALLY WANT TO SAY 'y' HERE IF SSH IS INSTALLED IN THE IMAGE UNLESS
+	  YOU ARE SURE YOU KNOW WHAT YOU ARE DOING!

--- a/tasks/image_configuration/ssh-regen-keys/fixup-ssh.sh
+++ b/tasks/image_configuration/ssh-regen-keys/fixup-ssh.sh
@@ -1,20 +1,23 @@
 #!/bin/bash
 
 if [ ! -e "/usr/sbin/sshd" ]; then
-    echo "ssh not installed"
+    echo -e "\n======================================================================="
+    echo -e "\tsshd not installed in target!"
+    echo -e "\tEither use a packagelist that includes sshd or disable"
+    echo -e "\tDS_REGENERATE_SSH_KEYS in distro-seed config"
+    echo -e "=======================================================================\n"
     exit 1
 fi
 
-servicename=sshfirstboot.service
+servicename=sshkeys.service
 servicefile="/etc/systemd/system/${servicename}"
 runscript="/usr/local/bin/regen_ssh_keys"
 
-touch /ssh_regenkeys
+rm -f /etc/ssh/ssh_host_*
 
 cat <<EOF > "$servicefile"
 [Unit]
-Description=Regenerate SSH keys for first boot
-ConditionPathExists=/ssh_regenkeys
+Description=Regenerate SSH keys if they do not exist
 Before=ssh.service
 
 [Service]
@@ -32,7 +35,6 @@ if [ -e "/usr/sbin/sshd" ]; then
     ssh-keygen -A
 fi
 
-rm /ssh_regenkeys
 EOF
 
 chmod a+x "$runscript"


### PR DESCRIPTION
Enabling this config options will now remove all host keys generated at install time by APT when configuring sshd. Additionally, it will install a script to the target that will use ssh-keygen -A which will generate host keys if they are not present at boot.

Fixes #41